### PR TITLE
recipes: ota: Replace 'apt install' with 'dpkg' to install debs

### DIFF
--- a/recipes-devtools/ota-upgrade/files/ota-upgrade.sh
+++ b/recipes-devtools/ota-upgrade/files/ota-upgrade.sh
@@ -218,7 +218,7 @@ upgrade_qti_debs() {
 
 	if [ -n "$files_to_install" ]; then
 		echo "#########$files_to_install###########"
-		apt install $files_to_install -y
+		DEBIAN_FRONTEND=noninteractive dpkg -i $files_to_install
 	else
 		echo "not found .deb file"
 	fi


### PR DESCRIPTION
Replace 'apt install' with 'dpkg' to install debs